### PR TITLE
Fix for SSC-564: Fix broken ElasticSearch specs

### DIFF
--- a/lib/tire/search.rb
+++ b/lib/tire/search.rb
@@ -138,7 +138,7 @@ module Tire
           STDERR.puts "[REQUEST FAILED] #{self.to_curl}\n"
           raise SearchRequestFailed, @response.to_s
         end
-        @json     = MultiJson.decode(@response.body)
+        @json     = JSON.parse(@response.body)
         @results  = Results::Collection.new(@json, @options)
         return self
       ensure


### PR DESCRIPTION
Incorrect json elasticsearch aggregation result parsing fixed by using JSON library instead of MultiJson.